### PR TITLE
Fix for install + clean include of directories

### DIFF
--- a/aicp_core/CMakeLists.txt
+++ b/aicp_core/CMakeLists.txt
@@ -12,19 +12,9 @@ find_package(Eigen3 REQUIRED)
 find_package(octomap REQUIRED)
 find_package(OpenCV 3.0 REQUIRED)
 
-# Add include directories
-#include_directories(
-  #include
-  #${libpointmatcher_INCLUDE_DIRS}
-  #${EIGEN3_INCLUDE_DIRS}
-  #${PCL_INCLUDE_DIRS}
-  #${OCTOMAP_INCLUDE_DIRS}
-#)
-
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES #${AICP_CORE_LIB} # libraries which will be visible outside 
-            aicpRegistration
+  LIBRARIES aicpRegistration# libraries which will be visible outside 
             aicpOverlap
             aicpClassification
             aicpUtils 
@@ -99,38 +89,26 @@ target_link_libraries(aicpRegistration ${libpointmatcher_LIBRARIES}
                                        ${PCL_LIBRARIES}
                                        yaml-cpp)
 
-                                      
-################  
-# Core library #
-################
-#add_library(${AICP_CORE_LIB} SHARED src/registration/app.cpp
-#                                    src/registration/yaml_configurator.cpp)
-#TARGET_INCLUDE_DIRECTORIES(${AICP_CORE_LIB} PUBLIC $<INSTALL_INTERFACE:include/aicp_core>)
-#target_link_libraries(${AICP_CORE_LIB} yaml-cpp
-#                                       aicpRegistration
-#                                       aicpOverlap
-#                                       aicpClassification
-#                                       aicpUtils)
 
 
 #############
 # Unit test #
 #############
 add_executable(aicp_test test/aicp_test.cpp)
-target_link_libraries(aicp_test aicpRegistration aicpOverlap aicpClassification aicpUtils) #${AICP_CORE_LIB}
+target_link_libraries(aicp_test aicpRegistration aicpOverlap aicpClassification aicpUtils)
 
 
 #############
 ## Install ##
 #############
 
-install(TARGETS aicpRegistration aicpOverlap aicpUtils aicpClassification #${AICP_CORE_LIB} 
+install(TARGETS aicpRegistration aicpOverlap aicpUtils aicpClassification 
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY include/aicp_registration/
-        DESTINATION include/aicp_registration) #${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        DESTINATION include/aicp_registration)
 
 install(DIRECTORY include/aicp_overlap/
         DESTINATION include/aicp_overlap)

--- a/aicp_core/CMakeLists.txt
+++ b/aicp_core/CMakeLists.txt
@@ -13,17 +13,17 @@ find_package(octomap REQUIRED)
 find_package(OpenCV 3.0 REQUIRED)
 
 # Add include directories
-include_directories(
-  include
-  ${libpointmatcher_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
-  ${PCL_INCLUDE_DIRS}
-  ${OCTOMAP_INCLUDE_DIRS}
-)
+#include_directories(
+  #include
+  #${libpointmatcher_INCLUDE_DIRS}
+  #${EIGEN3_INCLUDE_DIRS}
+  #${PCL_INCLUDE_DIRS}
+  #${OCTOMAP_INCLUDE_DIRS}
+#)
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${AICP_CORE_LIB} # libraries which will be visible outside 
+  LIBRARIES #${AICP_CORE_LIB} # libraries which will be visible outside 
             aicpRegistration
             aicpOverlap
             aicpClassification
@@ -44,6 +44,10 @@ add_library(aicpUtils SHARED src/utils/common.cpp
                              src/utils/fileIO.cpp
                              src/utils/icpMonitor.cpp
                              src/utils/filteringUtils.cpp)
+TARGET_INCLUDE_DIRECTORIES(aicpUtils SYSTEM PUBLIC ${libpointmatcher_INCLUDE_DIRS} 
+                                                   ${PCL_INCLUDE_DIRS}
+                                                   include)
+TARGET_INCLUDE_DIRECTORIES(aicpUtils PUBLIC $<INSTALL_INTERFACE:include/aicp_utils>)
 target_link_libraries(aicpUtils ${libpointmatcher_LIBRARIES}
                                 ${PCL_LIBRARIES})
 
@@ -52,14 +56,21 @@ target_link_libraries(aicpUtils ${libpointmatcher_LIBRARIES}
 # Octree-overlap #
 ##################
 add_library(aicpOverlap SHARED src/overlap/octrees_overlap.cpp)
+TARGET_INCLUDE_DIRECTORIES(aicpOverlap SYSTEM PUBLIC ${OCTOMAP_INCLUDE_DIRS}
+                                                     ${PCL_INCLUDE_DIRS}
+                                                     include)
+TARGET_INCLUDE_DIRECTORIES(aicpOverlap PUBLIC $<INSTALL_INTERFACE:include/aicp_overlap>)
 target_link_libraries(aicpOverlap ${PCL_LIBRARIES}
                                   ${OCTOMAP_LIBRARIES})
 
 
 #################
-# Clasification #
+# Classification #
 #################
 add_library(aicpClassification SHARED src/classification/svm.cpp)
+TARGET_INCLUDE_DIRECTORIES(aicpClassification SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIRS}
+                                                            include)
+TARGET_INCLUDE_DIRECTORIES(aicpClassification PUBLIC $<INSTALL_INTERFACE:include/aicp_classification>)
 target_link_libraries(aicpClassification ${OpenCV_LIBS})
                                          
 add_executable(aicp_classification_main src/classification/main.cpp)
@@ -77,7 +88,13 @@ target_link_libraries(aicp_classification_example aicpClassification
 ################
 add_library(aicpRegistration SHARED src/registration/pointmatcher_registration.cpp
                                     src/registration/aligned_cloud.cpp
-                                    src/registration/aligned_clouds_graph.cpp)
+                                    src/registration/aligned_clouds_graph.cpp
+                                    src/registration/app.cpp
+                                    src/registration/yaml_configurator.cpp)
+TARGET_INCLUDE_DIRECTORIES(aicpRegistration SYSTEM PUBLIC ${libpointmatcher_INCLUDE_DIRS}
+                                                          ${PCL_INCLUDE_DIRS}
+                                                          include)
+TARGET_INCLUDE_DIRECTORIES(aicpRegistration PUBLIC $<INSTALL_INTERFACE:include/aicp_registration>)
 target_link_libraries(aicpRegistration ${libpointmatcher_LIBRARIES}
                                        ${PCL_LIBRARIES}
                                        yaml-cpp)
@@ -86,36 +103,46 @@ target_link_libraries(aicpRegistration ${libpointmatcher_LIBRARIES}
 ################  
 # Core library #
 ################
-add_library(${AICP_CORE_LIB} SHARED src/registration/app.cpp
-                                    src/registration/yaml_configurator.cpp)
-target_link_libraries(${AICP_CORE_LIB} yaml-cpp
-                                       aicpRegistration
-                                       aicpOverlap
-                                       aicpClassification
-                                       aicpUtils)
+#add_library(${AICP_CORE_LIB} SHARED src/registration/app.cpp
+#                                    src/registration/yaml_configurator.cpp)
+#TARGET_INCLUDE_DIRECTORIES(${AICP_CORE_LIB} PUBLIC $<INSTALL_INTERFACE:include/aicp_core>)
+#target_link_libraries(${AICP_CORE_LIB} yaml-cpp
+#                                       aicpRegistration
+#                                       aicpOverlap
+#                                       aicpClassification
+#                                       aicpUtils)
 
 
 #############
 # Unit test #
 #############
 add_executable(aicp_test test/aicp_test.cpp)
-target_link_libraries(aicp_test ${AICP_CORE_LIB})
+target_link_libraries(aicp_test aicpRegistration aicpOverlap aicpClassification aicpUtils) #${AICP_CORE_LIB}
 
 
 #############
 ## Install ##
 #############
-install(TARGETS ${TARGETS} ${AICP_CORE_LIB}
+
+install(TARGETS aicpRegistration aicpOverlap aicpUtils aicpClassification #${AICP_CORE_LIB} 
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY include/aicp_registration/
-                  include/aicp_overlap/
-                  include/aicp_classification/
-                  include/aicp_utils/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-        FILES_MATCHING PATTERN "*.hpp")
+        DESTINATION include/aicp_registration) #${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+
+install(DIRECTORY include/aicp_overlap/
+        DESTINATION include/aicp_overlap)
+
+install(DIRECTORY include/aicp_classification/
+        DESTINATION include/aicp_classification)
+
+install(DIRECTORY include/aicp_utils/
+        DESTINATION include/aicp_utils)
+
+INSTALL(DIRECTORY config
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 ###############  
 # Extra Tools #


### PR DESCRIPTION
Changed include_directories to target_include_directories for dependencies to work in catkin config --install with catkin build.
Commented the core library part that was not working and separated libraries.
Installed targets properly.